### PR TITLE
fix: change create at variable name

### DIFF
--- a/Sources/App/Extension/Message/Message+Get.swift
+++ b/Sources/App/Extension/Message/Message+Get.swift
@@ -14,6 +14,6 @@ extension Message {
         let id: UUID
         let user: User.Get
         let content: String
-        let createAt: Date
+        let createdAt: Date
     }
 }

--- a/Sources/App/Models/User/User+Extension.swift
+++ b/Sources/App/Models/User/User+Extension.swift
@@ -30,7 +30,7 @@ extension User {
                 name: user.name
             ),
             content: message.content,
-            createAt: messageSendTime
+            createdAt: messageSendTime
         )
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the property name for message creation timestamp from `createAt` to `createdAt` in the message structure.
	- Fixed a typo in the `getMessageWithSender` method to ensure proper alignment with the updated property name.

These changes enhance consistency and clarity in the app's message handling features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->